### PR TITLE
core: healthd: Use SYSFS_BATTERY_VOLTAGE as fallback for ChargingVoltage

### DIFF
--- a/healthd/BatteryMonitor.cpp
+++ b/healthd/BatteryMonitor.cpp
@@ -45,6 +45,7 @@
 #define POWER_SUPPLY_SUBSYSTEM "power_supply"
 #define POWER_SUPPLY_SYSFS_PATH "/sys/class/" POWER_SUPPLY_SUBSYSTEM
 #define SYSFS_BATTERY_CURRENT "/sys/class/power_supply/battery/current_now"
+#define SYSFS_BATTERY_VOLTAGE "/sys/class/power_supply/battery/voltage_now"
 #define FAKE_BATTERY_CAPACITY 42
 #define FAKE_BATTERY_TEMPERATURE 424
 #define MILLION 1.0e6
@@ -367,9 +368,10 @@ void BatteryMonitor::updateValues(void) {
             path.appendFormat("%s/%s/voltage_now", POWER_SUPPLY_SYSFS_PATH,
                               mChargerNames[i].string());
 
-            int ChargingVoltage =
-                (access(path.string(), R_OK) == 0) ? getIntField(path) :
-                DEFAULT_VBUS_VOLTAGE;
+            int ChargingVoltage = (access(path.string(), R_OK) == 0) ? getIntField(path) : 0;
+            if (ChargingVoltage == 0 && access(SYSFS_BATTERY_VOLTAGE, R_OK) == 0) {
+                ChargingVoltage = getIntField(String8(SYSFS_BATTERY_VOLTAGE));
+            }
 
             // there are devices that have the file but with a value of 0
             if (ChargingVoltage == 0) {


### PR DESCRIPTION
This should covers legacy devices as well.

Fixes: 1eb28844c7a ("core: healthd: Read charger voltage from the actual charger")
